### PR TITLE
Fix Chrome trying to autofill password into Event/Ad fields

### DIFF
--- a/cse_site/ubs_project/templates/ubs_project/advertisement_create.html
+++ b/cse_site/ubs_project/templates/ubs_project/advertisement_create.html
@@ -9,6 +9,9 @@
 {% block content %}
 <form action="{% url 'advertisement_create_handler' %}" method="post">
     {% csrf_token %}
+    <!-- fake fields are a workaround for chrome autofill getting the wrong fields -->
+    <input style="display: none" type="text" name="fakeusernameremembered" />
+    <input style="display: none" type="password" name="fakepasswordremembered" />
     <div class="form-group">
         <label>Title</label>
         <input name="title" type="text" class="form-control" required>

--- a/cse_site/ubs_project/templates/ubs_project/advertisement_update.html
+++ b/cse_site/ubs_project/templates/ubs_project/advertisement_update.html
@@ -8,6 +8,9 @@
 {% block content %}
     <form action="{% url 'advertisement_update_handler' advertisement.id %}" method="post">
         {% csrf_token %}
+        <!-- fake fields are a workaround for chrome autofill getting the wrong fields -->
+        <input style="display: none" type="text" name="fakeusernameremembered" />
+        <input style="display: none" type="password" name="fakepasswordremembered" />
         <div class="form-group">
             <label>Title</label>
             <input name="title" type="text" class="form-control" value="{{ advertisement.title }}" required >

--- a/cse_site/ubs_project/templates/ubs_project/event_create.html
+++ b/cse_site/ubs_project/templates/ubs_project/event_create.html
@@ -9,6 +9,9 @@
 {% block content %}
 <form action="{% url 'event_create_handler' %}" method="post">
     {% csrf_token %}
+    <!-- fake fields are a workaround for chrome autofill getting the wrong fields -->
+    <input style="display: none" type="text" name="fakeusernameremembered" />
+    <input style="display: none" type="password" name="fakepasswordremembered" />
     <div class="form-group">
         <label>Title</label>
         <input name="title" type="text" class="form-control" required>

--- a/cse_site/ubs_project/templates/ubs_project/event_update.html
+++ b/cse_site/ubs_project/templates/ubs_project/event_update.html
@@ -8,6 +8,9 @@
 {% block content %}
     <form action="{% url 'event_update_handler' event.id %}" method="post">
         {% csrf_token %}
+        <!-- fake fields are a workaround for chrome autofill getting the wrong fields -->
+        <input style="display: none" type="text" name="fakeusernameremembered" />
+        <input style="display: none" type="password" name="fakepasswordremembered" />
         <div class="form-group">
             <label>Title</label>
             <input name="title" type="text" class="form-control" value="{{ event.title }}" required >


### PR DESCRIPTION
Chrome kept trying to autofill passwords/login info for Ads and Events. This is a stupid workaround because autofill=off doesn't work for latest Chrome.